### PR TITLE
Fix for  --allow-no-subscriptions logins

### DIFF
--- a/Scripts/Helpers/Get-AzScopeTree.ps1
+++ b/Scripts/Helpers/Get-AzScopeTree.ps1
@@ -65,6 +65,9 @@ function Get-AzScopeTree {
         # Write-Host "##[command] Get-AzSubscription"
         $subscriptions = Invoke-AzCli account list --all
         foreach ($subscription in $subscriptions) {
+            if ($subscription.id -eq $subscription.tenantId) {
+                continue 
+                }
             if ($tenantId -eq $subscription.tenantId) {
                 # Ignore subscriptions in other tenants the identity has access permissions (only for interactive users)
                 $resourceGroupIdsHashTable = @{}


### PR DESCRIPTION
When logging in with az login  --allow-no-subscriptions there is an extra entry for az account list that has the subscriptionId set as the TenantId This fix checks for that and skips the entry